### PR TITLE
change readme encoding for pypi.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Auto-agreement tools based on extra-resources are <b>not provided</b> in this li
 
 You can chose a language (French or English) and typography will be automatically handled based on it.\
 For example:\
-In French 'Ma liste d'Ã©lÃ©ments:' becomes "Ma liste d'Ã©lÃ©ments :".\
+In French 'Ma liste d'éléments:' becomes "Ma liste d'éléments :".\
 In English "My list of items :" will become "My list of items:"
 
 A period will always be followed by a capitalized word.
@@ -42,11 +42,11 @@ A period will always be followed by a capitalized word.
 Contractions are automatically handled based on the selected language (French or English).
 
 ```python
-word_1 = 'le dÃ©passement'
+word_1 = 'le dépassement'
 word_2 = 'les hausses'
 
-self.free_text('Ã€ cause de', word_1) # "Ã€ cause du dÃ©passement"
-self.free_text('Ã€ cause de', word_2) # "Ã€ cause des hausses"
+self.free_text('À cause de', word_1) # "À cause du dépassement"
+self.free_text('À cause de', word_2) # "À cause des hausses"
 ```
 
 ## CoreNLG functions


### PR DESCRIPTION
Readme on pypi.org wasn't properly encoded