### PR TITLE
remove self argument from enum function

### DIFF
--- a/CoreNLG/IterElems.py
+++ b/CoreNLG/IterElems.py
@@ -142,8 +142,7 @@ class IterElems:
         return elem_list[:self.max_elem]
 
 
-def enum(self,
-         pattern,
+def enum(pattern,
          max_elem=None,
          nb_elem_bullet=None,
          begin_w=None,


### PR DESCRIPTION
The method enum had a "self" argument which was a copy pasted argument from the method enum of the class IterElems